### PR TITLE
Check max file size before upload

### DIFF
--- a/src/components/data-providers/SnapshotUploader.tsx
+++ b/src/components/data-providers/SnapshotUploader.tsx
@@ -49,7 +49,21 @@ export function SnapshotUploader({ onSnapshotLoaded }: SnapshotUploaderProps) {
   const handleFileUpload = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !worker) return;
-    
+
+    const maxSizeStr = import.meta.env.VITE_MAX_FILE_SIZE;
+    const maxSize = maxSizeStr ? parseInt(maxSizeStr, 10) : undefined;
+    if (maxSize && file.size > maxSize) {
+      const message = `File size exceeds limit of ${maxSize} bytes`;
+      setError(message);
+      eventBus.emit('snapshot.error', {
+        fileName: file.name,
+        error: message,
+        timestamp: Date.now()
+      });
+      e.target.value = '';
+      return;
+    }
+
     // Reset states
     setIsLoading(true);
     setError(null);


### PR DESCRIPTION
## Summary
- check file size against `VITE_MAX_FILE_SIZE`
- emit `snapshot.error` when file exceeds limit

## Testing
- `pnpm lint` *(fails: couldn't find eslint config)*
- `pnpm test` *(fails: vitest not found)*