### PR TITLE
Implement deterministic series keys

### DIFF
--- a/src/types/otlp.ts
+++ b/src/types/otlp.ts
@@ -79,6 +79,7 @@ export interface DataPoint {
   startTimeUnixNano?: string;
   asDouble?: number;
   asInt?: string;
+  seriesKey?: string;
 }
 
 export interface HistogramDataPoint {
@@ -90,6 +91,7 @@ export interface HistogramDataPoint {
   bucketCounts?: string[];
   explicitBounds?: number[];
   exemplars?: Exemplar[];
+  seriesKey?: string;
 }
 
 export interface SummaryDataPoint {
@@ -99,6 +101,7 @@ export interface SummaryDataPoint {
   count: string;
   sum: number;
   quantileValues: QuantileValue[];
+  seriesKey?: string;
 }
 
 export interface QuantileValue {

--- a/src/utils/__tests__/seriesKey.test.ts
+++ b/src/utils/__tests__/seriesKey.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { buildSeriesKey } from '../seriesKey';
+
+describe('buildSeriesKey', () => {
+  it('creates deterministic key from attrs', () => {
+    const attrs = { 'state': 'user', 'process.pid': 1234, 'host.name': 'alpha' };
+    const key = buildSeriesKey('process.cpu.time', attrs);
+    expect(key).toBe('process.cpu.time|host.name=alpha,process.pid=1234,state=user');
+  });
+});

--- a/src/utils/seriesKey.ts
+++ b/src/utils/seriesKey.ts
@@ -1,0 +1,12 @@
+export type SeriesKey = string;
+
+export function buildSeriesKey(
+  metricName: string,
+  attrs: Record<string, string | number | boolean>
+): SeriesKey {
+  const kv = Object.entries(attrs)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${String(v)}`)
+    .join(',');
+  return `${metricName}|${kv}`;
+}

--- a/src/workers/otlpJsonParser.worker.ts
+++ b/src/workers/otlpJsonParser.worker.ts
@@ -6,6 +6,7 @@
  */
 
 import { OtlpMetricsJson, ParsedSnapshot, MetricType, Temporality } from '../types/otlp';
+import { buildSeriesKey } from '../utils/seriesKey';
 
 // Define the message types for Worker communication
 interface WorkerMessage {
@@ -177,14 +178,16 @@ function processResources(
         const monotonic = determineMonotonic(metric, metricType);
         
         // Extract datapoints based on metric type
-        const dataPoints = extractDataPoints(metric, metricType, options.includeZeroValues);
+        const dataPoints = extractDataPoints(metric, metric.name, metricType, options.includeZeroValues);
         
         // Collect all unique attribute keys from datapoints
         const attributeKeysSet = new Set<string>();
+        const uniqueSeriesKeys = new Set<string>();
         dataPoints.forEach(dp => {
           if (dp.attributes) {
             Object.keys(dp.attributes).forEach(key => attributeKeysSet.add(key));
           }
+          if (dp.seriesKey) uniqueSeriesKeys.add(dp.seriesKey);
         });
         const attributeKeys = Array.from(attributeKeysSet);
         
@@ -206,10 +209,9 @@ function processResources(
         // Update counts
         parsedSnapshot.metricCount++;
         parsedSnapshot.totalDataPoints += dataPoints.length;
-        
-        // Estimate series count - unique combinations of attribute values
-        // For simplicity, we'll use datapoint count as a proxy for now
-        parsedSnapshot.totalSeries += dataPoints.length;
+
+        // Unique series count based on deterministic key
+        parsedSnapshot.totalSeries += uniqueSeriesKeys.size;
         
         parsedScope.metricIds.push(metricId);
       });
@@ -290,66 +292,74 @@ function normalizeStringValue(value: string): string {
 /**
  * Extract data points based on metric type
  */
-function extractDataPoints(metric: any, type: MetricType, includeZeroValues: boolean): any[] {
+function extractDataPoints(metric: any, metricName: string, type: MetricType, includeZeroValues: boolean): any[] {
   const dataPoints = [];
   
   if (type === 'gauge' && metric.gauge?.dataPoints) {
     for (const dp of metric.gauge.dataPoints) {
-      const value = dp.asDouble !== undefined ? dp.asDouble : 
+      const value = dp.asDouble !== undefined ? dp.asDouble :
                     dp.asInt !== undefined ? parseInt(dp.asInt, 10) : 0;
-      
+
       if (!includeZeroValues && value === 0) continue;
-      
+
+      const attrs = extractAttributes(dp.attributes, true);
       dataPoints.push({
-        attributes: extractAttributes(dp.attributes, true),
+        attributes: attrs,
         timeUnixNano: dp.timeUnixNano,
         startTimeUnixNano: dp.startTimeUnixNano,
-        value
+        value,
+        seriesKey: buildSeriesKey(metricName, attrs)
       });
     }
   } else if (type === 'sum' && metric.sum?.dataPoints) {
     for (const dp of metric.sum.dataPoints) {
-      const value = dp.asDouble !== undefined ? dp.asDouble : 
+      const value = dp.asDouble !== undefined ? dp.asDouble :
                     dp.asInt !== undefined ? parseInt(dp.asInt, 10) : 0;
-      
+
       if (!includeZeroValues && value === 0) continue;
-      
+
+      const attrs = extractAttributes(dp.attributes, true);
       dataPoints.push({
-        attributes: extractAttributes(dp.attributes, true),
+        attributes: attrs,
         timeUnixNano: dp.timeUnixNano,
         startTimeUnixNano: dp.startTimeUnixNano,
-        value
+        value,
+        seriesKey: buildSeriesKey(metricName, attrs)
       });
     }
   } else if (type === 'histogram' && metric.histogram?.dataPoints) {
     for (const dp of metric.histogram.dataPoints) {
       const count = typeof dp.count === 'string' ? parseInt(dp.count, 10) : dp.count;
-      
+
       if (!includeZeroValues && count === 0) continue;
-      
+
+      const attrs = extractAttributes(dp.attributes, true);
       dataPoints.push({
-        attributes: extractAttributes(dp.attributes, true),
+        attributes: attrs,
         timeUnixNano: dp.timeUnixNano,
         startTimeUnixNano: dp.startTimeUnixNano,
         count,
         sum: dp.sum,
         bucketCounts: dp.bucketCounts?.map(c => typeof c === 'string' ? parseInt(c, 10) : c),
-        explicitBounds: dp.explicitBounds
+        explicitBounds: dp.explicitBounds,
+        seriesKey: buildSeriesKey(metricName, attrs)
       });
     }
   } else if (type === 'summary' && metric.summary?.dataPoints) {
     for (const dp of metric.summary.dataPoints) {
       const count = typeof dp.count === 'string' ? parseInt(dp.count, 10) : dp.count;
-      
+
       if (!includeZeroValues && count === 0) continue;
-      
+
+      const attrs = extractAttributes(dp.attributes, true);
       dataPoints.push({
-        attributes: extractAttributes(dp.attributes, true),
+        attributes: attrs,
         timeUnixNano: dp.timeUnixNano,
         startTimeUnixNano: dp.startTimeUnixNano,
         count,
         sum: dp.sum,
-        quantileValues: dp.quantileValues
+        quantileValues: dp.quantileValues,
+        seriesKey: buildSeriesKey(metricName, attrs)
       });
     }
   }
@@ -409,22 +419,22 @@ function determineMonotonic(metric: any, type: MetricType): boolean | undefined 
 function computeMetricStatistics(parsedSnapshot: ParsedSnapshot): void {
   // Would compute various statistics for each metric
   // This is just a placeholder - a real implementation would be more complex
-  
+
   // Update total counts
   let totalDataPoints = 0;
-  let totalSeries = 0;
-  
+  const seriesKeys = new Set<string>();
+
   Object.values(parsedSnapshot.metrics).forEach(metric => {
     const dataPointCount = metric.dataPoints.length;
     totalDataPoints += dataPointCount;
-    
-    // Calculate series count (unique combinations of attribute values)
-    // This is a simplified calculation
-    totalSeries += dataPointCount;
+
+    metric.dataPoints.forEach(dp => {
+      if (dp.seriesKey) seriesKeys.add(dp.seriesKey);
+    });
   });
-  
+
   parsedSnapshot.totalDataPoints = totalDataPoints;
-  parsedSnapshot.totalSeries = totalSeries;
+  parsedSnapshot.totalSeries = seriesKeys.size;
 }
 
 export default {} as typeof Worker & { new(): Worker };


### PR DESCRIPTION
## Summary
- add `buildSeriesKey` util following data contract spec
- generate `seriesKey` for all extracted datapoints
- track unique series when parsing metrics and during statistics
- expose optional `seriesKey` on datapoint types
- add unit test for `buildSeriesKey`

## Testing
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*