### PR TITLE
Add Storybook with MetricCard story

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-links'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  docs: {
+    autodocs: true
+  }
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/src/components/metrics/MetricCard.stories.tsx
+++ b/src/components/metrics/MetricCard.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MetricCard } from './MetricCard';
+import { useStore } from '../../services/stateStore';
+import type { ParsedMetric, ParsedSnapshot } from '../../types/otlp';
+
+const snapshotId = 'snapshot1';
+const metricId = 'metric1';
+
+const metric: ParsedMetric = {
+  id: metricId,
+  name: 'cpu_usage',
+  description: 'CPU usage percent',
+  unit: 'percent',
+  type: 'gauge',
+  temporality: 'cumulative',
+  monotonic: false,
+  dataPoints: [],
+  attributeKeys: ['host', 'cpu'],
+  resourceIds: [],
+  scopeIds: [],
+};
+
+const snapshot: ParsedSnapshot = {
+  id: snapshotId,
+  timestamp: Date.now(),
+  resources: [],
+  metrics: { [metricId]: metric },
+  metricCount: 1,
+  totalSeries: 1,
+  totalDataPoints: 0,
+};
+
+if (!useStore.getState().snapshots[snapshotId]) {
+  useStore.getState().addSnapshot(snapshot);
+}
+
+const meta: Meta<typeof MetricCard> = {
+  title: 'Metrics/MetricCard',
+  component: MetricCard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MetricCard>;
+
+export const Default: Story = {
+  render: () => (
+    <MetricCard
+      metricId={metricId}
+      snapshotId={snapshotId}
+      isExpanded={false}
+      isSelected={false}
+      onSelect={() => {}}
+    />
+  ),
+};


### PR DESCRIPTION
## Summary
- setup `.storybook` with Vite React config
- add Storybook preview config including global CSS
- create a basic story for `MetricCard`

## Testing
- `pnpm lint` *(fails: couldn't find eslint config)*
- `pnpm test` *(fails: vitest not found)*