### PR TITLE
Fix pnpm flags and issue generator token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,13 @@ jobs:
         run_install: false
     
     - name: Install dependencies
-      run: pnpm install --no-frozen-lockfile
+      run: pnpm install --no-lockfile
     
     - name: Lint
-      run: pnpm lint || true
-    
+      run: pnpm lint
+
     - name: Test
-      run: pnpm test || true
-    
+      run: pnpm test
+
     - name: Build
-      run: pnpm build || true
+      run: pnpm build

--- a/.github/workflows/generate-issues.yml
+++ b/.github/workflows/generate-issues.yml
@@ -41,7 +41,7 @@ jobs:
           run_install: false
       
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile @octokit/rest
+        run: pnpm install --no-lockfile @octokit/rest
       
       - name: Debug Implementation Plan structure
         run: |
@@ -52,6 +52,6 @@ jobs:
           grep -n "### Phase" docs/72-implementation-Plan.md || echo "No matches for ### Phase"
       
       - name: Generate issues
-        run: node scripts/generate-issues.js ${{ github.event.inputs.phase }} ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/generate-issues.js ${{ github.event.inputs.phase }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/generate-issues.js
+++ b/scripts/generate-issues.js
@@ -2,10 +2,10 @@
  * Script to generate GitHub issues from the implementation plan
  * 
  * Usage:
- * node scripts/generate-issues.js <phase-number> <github-token>
+ * GITHUB_TOKEN=ghp_12345abcdef node scripts/generate-issues.js <phase-number>
  * 
  * Example:
- * node scripts/generate-issues.js 0 ghp_12345abcdef
+ * GITHUB_TOKEN=ghp_12345abcdef node scripts/generate-issues.js 0
  */
 
 import fs from 'fs';
@@ -18,10 +18,10 @@ const IMPLEMENTATION_PLAN_PATH = './docs/72-implementation-Plan.md';
 
 // Parse command line arguments
 const phaseArg = process.argv[2];
-const token = process.argv[3];
+const token = process.env.GITHUB_TOKEN;
 
 if (!phaseArg || !token) {
-  console.error('Usage: node scripts/generate-issues.js <phase-number> <github-token>');
+  console.error('Usage: GITHUB_TOKEN=<token> node scripts/generate-issues.js <phase-number>');
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- fix pnpm install flags in CI workflows
- stop ignoring lint/test/build failures in CI
- install dependencies with new flag in issue generator workflow
- pass GITHUB_TOKEN via env only and update issue generator script

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test` *(fails: vitest not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency installation process in workflows to change lockfile handling.
  - Improved CI reliability by ensuring lint, test, and build failures stop the workflow.
  - Changed authentication for issue generation to use an environment variable instead of a command-line argument.
  - Updated usage instructions for issue generation to reflect the new authentication method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->