### PR TITLE
Complete store slice stubs

### DIFF
--- a/src/state/__tests__/slices.test.ts
+++ b/src/state/__tests__/slices.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { create } from 'zustand';
+import { immer } from 'zustand/middleware/immer';
+import { createMetricsSlice } from '../metricsSlice';
+import { createUiSlice } from '../uiSlice';
+import { createDiffSlice } from '../diffSlice';
+import { createCardinalitySlice } from '../cardinalitySlice';
+import type { AppStore } from '../store';
+
+function createTestStore() {
+  return create<AppStore>()(
+    immer((set, get) => ({
+      ...createMetricsSlice(set, get),
+      ...createUiSlice(set, get),
+      ...createDiffSlice(set, get),
+      ...createCardinalitySlice(set, get),
+    }))
+  );
+}
+
+describe('DiffSlice actions', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('sets and clears diff results', () => {
+    store.getState().setDiffResult('snapA', { diff: 1 });
+    expect(store.getState().diffResults['snapA']).toEqual({ diff: 1 });
+
+    store.getState().clearDiffResults();
+    expect(Object.keys(store.getState().diffResults).length).toBe(0);
+  });
+});
+
+describe('CardinalitySlice actions', () => {
+  let store: ReturnType<typeof createTestStore>;
+
+  beforeEach(() => {
+    store = createTestStore();
+  });
+
+  it('sets analysis and recommendations', () => {
+    store.getState().setCardinalityAnalysis('snapA', { series: 5 });
+    store.getState().setRecommendations('snapA', { note: true });
+
+    expect(store.getState().cardinalityAnalysis['snapA']).toEqual({ series: 5 });
+    expect(store.getState().recommendations['snapA']).toEqual({ note: true });
+  });
+
+  it('updates cost model', () => {
+    store.getState().updateCostModel({ costPerSeries: 2 });
+    expect(store.getState().costModel.costPerSeries).toBe(2);
+  });
+
+  it('clears cardinality state', () => {
+    store.getState().setCardinalityAnalysis('snapB', { a: 1 });
+    store.getState().clearCardinality();
+    expect(Object.keys(store.getState().cardinalityAnalysis).length).toBe(0);
+    expect(Object.keys(store.getState().recommendations).length).toBe(0);
+  });
+});

--- a/src/state/cardinalitySlice.ts
+++ b/src/state/cardinalitySlice.ts
@@ -12,6 +12,10 @@ export interface CardinalitySlice {
   cardinalityAnalysis: Record<string, any>;
   recommendations: Record<string, any>;
   costModel: CostModel;
+  setCardinalityAnalysis: (snapshotId: string, analysis: any) => void;
+  setRecommendations: (snapshotId: string, recs: any) => void;
+  updateCostModel: (partial: Partial<CostModel>) => void;
+  clearCardinality: () => void;
 }
 
 export const createCardinalitySlice: StateCreator<
@@ -28,6 +32,31 @@ export const createCardinalitySlice: StateCreator<
     retentionPeriodDays: 30,
     scrapeIntervalSeconds: 60,
     currency: 'USD',
+  },
+
+  setCardinalityAnalysis: (snapshotId, analysis) => {
+    set((state) => {
+      state.cardinalityAnalysis[snapshotId] = analysis;
+    });
+  },
+
+  setRecommendations: (snapshotId, recs) => {
+    set((state) => {
+      state.recommendations[snapshotId] = recs;
+    });
+  },
+
+  updateCostModel: (partial) => {
+    set((state) => {
+      state.costModel = { ...state.costModel, ...partial };
+    });
+  },
+
+  clearCardinality: () => {
+    set((state) => {
+      state.cardinalityAnalysis = {};
+      state.recommendations = {};
+    });
   },
 });
 

--- a/src/state/diffSlice.ts
+++ b/src/state/diffSlice.ts
@@ -2,6 +2,8 @@ import { StateCreator } from 'zustand';
 
 export interface DiffSlice {
   diffResults: Record<string, any>;
+  setDiffResult: (snapshotId: string, result: any) => void;
+  clearDiffResults: () => void;
 }
 
 export const createDiffSlice: StateCreator<
@@ -11,5 +13,17 @@ export const createDiffSlice: StateCreator<
   DiffSlice
 > = () => ({
   diffResults: {},
+
+  setDiffResult: (snapshotId, result) => {
+    set((state) => {
+      state.diffResults[snapshotId] = result;
+    });
+  },
+
+  clearDiffResults: () => {
+    set((state) => {
+      state.diffResults = {};
+    });
+  },
 });
 


### PR DESCRIPTION
## Summary
- add stub actions for diff and cardinality slices
- include unit tests for new store actions

## Testing
- `npx vitest run` *(fails: could not download runner in offline environment)*